### PR TITLE
Time

### DIFF
--- a/zephyr/lib/Time.swift
+++ b/zephyr/lib/Time.swift
@@ -16,9 +16,9 @@ public var SYS_FREQUENCY: Int32 { return CONFIG_SYS_CLOCK_TICKS_PER_SEC }
 // Zephyr can be configured for 64-bit or 32-bit time values.
 // Set USE_64BIT_TICK to true for 64-bit, false for 32-bit.
 #if USE_64BIT_TICK
-public typealias Tick = UInt64
+public typealias Tick = Int64
 #else
-public typealias Tick = UInt32
+public typealias Tick = Int32
 #endif
 
 public protocol TimeoutConvertible {
@@ -80,12 +80,12 @@ public extension Duration {
     Duration(ticks: 0)
   }
 
-  static func from(milliseconds ms: UInt64) -> Duration {
-    Duration(ticks: Tick(ms * UInt64(SYS_FREQUENCY) / 1000))
+  static func from(milliseconds ms: Int64) -> Duration {
+    Duration(ticks: Tick(ms * Int64(SYS_FREQUENCY) / 1000))
   }
 
-  static func from(seconds s: UInt64) -> Duration {
-    Duration(ticks: Tick(s * UInt64(SYS_FREQUENCY)))
+  static func from(seconds s: Int64) -> Duration {
+    Duration(ticks: Tick(s * Int64(SYS_FREQUENCY)))
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new Swift module for Zephyr time management and cleans up legacy or unused C code. The main focus is on providing type-safe abstractions for durations, instants, and timeouts in Swift, making it easier to work with Zephyr system time. Additionally, some C header declarations are commented out and an EditorConfig file is added for consistent code style.

**Time management module for Zephyr in Swift:**

* Added a new `Time.swift` module that defines type-safe abstractions for `Duration`, `Instant`, and `Timeout`, as well as conversion utilities and a `sleep` function for Zephyr-based systems. This module supports both 32-bit and 64-bit tick configurations and provides marker types for "forever" and "no wait" timeouts. (`zephyr/lib/Time.swift`, [zephyr/lib/Time.swiftR1-R149](diffhunk://#diff-dfb9350bf3eada4a85a6b7947b400c03fdc7b79e8035556bf4e19840e22167a8R1-R149))

**Code cleanup and removal:**

* Removed the C implementation of `msleep` from `Time.c`, eliminating an unnecessary linkable symbol for Swift interop, as the new Swift abstractions supersede it. (`zephyr-sys/src/Time.c`, [zephyr-sys/src/Time.cL1-L13](diffhunk://#diff-5dc12d77233105a164064e7e115660b58dbd8d60780d9a7e21c221f12d95f39cL1-L13))
* Commented out unused GPIO device and pin configuration function declarations in the bridging header, likely because they are no longer needed or are being refactored. (`zephyr-sys/include/BridgingHeader.h`, [[1]](diffhunk://#diff-d2cf8113f19886113eb5d9d18d9f0520b6d1e187f4b0499bc4f2b87dae1ff3b9L51-R51) [[2]](diffhunk://#diff-d2cf8113f19886113eb5d9d18d9f0520b6d1e187f4b0499bc4f2b87dae1ff3b9L65-R66)

**Tooling and code style:**

* Added an `.editorconfig` file to enforce consistent coding styles across different editors and IDEs, specifying indentation, line endings, and charset preferences. (`.editorconfig`, [.editorconfigR1-R22](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR1-R22))