### PR TITLE
cicd: Updated the checkov linter version from 3.2.470 to 3.2.471 in .trunk/trunk.yaml

### DIFF
--- a/.devcontainer/configure.sh
+++ b/.devcontainer/configure.sh
@@ -11,9 +11,9 @@ DIR="$(dirname "${REAL_PARENT_DIR}")"
 
 # configure environment
 if [[ ! -d "/home/ubuntu/.oh-my-zsh" ]]; then
-	curl -fsSLo /tmp/ohmyzsh-install.sh https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
-	bash /tmp/ohmyzsh-install.sh --unattended || true
-	rm -f /tmp/ohmyzsh-install.sh
+  curl -fsSLo /tmp/ohmyzsh-install.sh https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
+  bash /tmp/ohmyzsh-install.sh --unattended || true
+  rm -f /tmp/ohmyzsh-install.sh
 fi
 
 sudo ln -sf "${DIR}/scripts/aliases.sh" /etc/profile.d/aliases.sh

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -24,7 +24,7 @@ lint:
     - swiftformat@0.55.5
     - swiftlint@0.58.2
     - actionlint@1.7.7
-    - checkov@3.2.470
+    - checkov@3.2.471
     - git-diff-check
     - hadolint@2.13.1
     - markdownlint@0.45.0

--- a/zephyr-sys/include/BridgingHeader.h
+++ b/zephyr-sys/include/BridgingHeader.h
@@ -62,5 +62,4 @@
  * @param flags Additional configuration flags (pull-up/down, etc.)
  * @return 0 on success, negative error code on failure
  */
-// int configure_gpio_pin(const struct device *dev, uint8_t pin, gpio_flags_t dir,
-//                        gpio_flags_t flags);
+// int configure_gpio_pin(const struct device *dev, uint8_t pin, gpio_flags_t dir, gpio_flags_t flags);


### PR DESCRIPTION
This pull request makes minor updates to the project configuration and code documentation. The most notable changes are an update to a linter version and a small formatting adjustment in a header file.

Configuration updates:
* Updated the `checkov` linter version from `3.2.470` to `3.2.471` in `.trunk/trunk.yaml`.

Documentation/code formatting:
* Reformatted a commented-out function declaration in `zephyr-sys/include/BridgingHeader.h` to be on a single line for improved readability.