### PR TITLE
fix: Add missing if statement for CONFIG_HELLO in CMakeLists.txt

### DIFF
--- a/samples/modules/hello/CMakeLists.txt
+++ b/samples/modules/hello/CMakeLists.txt
@@ -6,6 +6,10 @@
 # and Zephyr's build system for embedded development.
 # ==============================================================================
 
+if(CONFIG_HELLO)
+
 project(Hello)
 enable_language(Swift)
 swift_library()
+
+endif()


### PR DESCRIPTION
This pull request introduces a conditional build for the Hello module by wrapping its CMake configuration in an `if(CONFIG_HELLO)` block. This ensures that the Hello project and its associated Swift library are only included when the `CONFIG_HELLO` configuration option is enabled. 

Build configuration improvement:

* Wrapped the Hello module's CMake configuration in an `if(CONFIG_HELLO)` conditional to allow selective inclusion based on configuration. (`samples/modules/hello/CMakeLists.txt`)