### PR TITLE
fix: Add missing if statement for CONFIG_SWIFT in CMakeLists.txt

### DIFF
--- a/zephyr-sys/CMakeLists.txt
+++ b/zephyr-sys/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(CONFIG_SWIFT)
+
 # Define the zephyr-sys library
 add_library(ZephyrSys STATIC)
 
@@ -11,3 +13,5 @@ target_include_directories(ZephyrSys PUBLIC include)
 
 # Link with Zephyr if available
 target_link_libraries(ZephyrSys PUBLIC zephyr)
+
+endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(CONFIG_SWIFT)
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/../toolchain.cmake)
 
 # Find all Swift source files
@@ -54,4 +56,6 @@ else()
   # Fallback: empty library if no Swift sources
   add_library(Zephyr INTERFACE)
   target_link_libraries(Zephyr INTERFACE ZephyrSys)
+endif()
+
 endif()


### PR DESCRIPTION
This pull request introduces conditional compilation for Swift support in both the `zephyr-sys` and `zephyr` CMake build scripts. The changes ensure that certain build steps are only executed if the `CONFIG_SWIFT` configuration is set, improving build flexibility and preventing unnecessary operations when Swift is not enabled.

Build system improvements for Swift support:

* Added an `if(CONFIG_SWIFT)` guard to `zephyr-sys/CMakeLists.txt` to conditionally define the `ZephyrSys` library and its dependencies only when Swift support is enabled.
* Wrapped the `target_link_libraries(ZephyrSys PUBLIC zephyr)` and related build steps inside the `CONFIG_SWIFT` conditional block in `zephyr-sys/CMakeLists.txt`.
* Added an `if(CONFIG_SWIFT)` guard to `zephyr/CMakeLists.txt` to ensure Swift-related build steps are only executed when Swift support is enabled.
* Wrapped the finalization of the Zephyr library creation and linking in `zephyr/CMakeLists.txt` with the `CONFIG_SWIFT` conditional block.