### PR TITLE
fix: library and application build logic

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "lineLength": 100,
+  "indentation": {
+    "spaces": 2
+  },
+  "tabWidth": 2,
+  "maximumBlankLines": 1,
+  "respectsExistingLineBreaks": false,
+  "lineBreakBeforeControlFlowKeywords": false,
+  "lineBreakBeforeEachArgument": false,
+  "lineBreakBeforeEachGenericRequirement": false,
+  "prioritizeKeepingFunctionOutputTogether": false,
+  "indentConditionalCompilationBlocks": true,
+  "lineBreakAroundMultilineExpressionChainComponents": false,
+  "indentSwitchCaseLabels": false,
+  "fileScopedDeclarationPrivacy": {
+    "accessLevel": "private"
+  },
+  "spacesAroundRangeFormationOperators": false
+}

--- a/cmake/SwiftLibrary.cmake
+++ b/cmake/SwiftLibrary.cmake
@@ -169,91 +169,11 @@ function(zephyr_swift_library)
     list(APPEND SWIFT_DEFINES "-DSWIFT_DEBUG_INFO")
   endif()
 
-  # Build Swift module search paths for compilation Include the core Zephyr
-  # Swift module so libraries can import Zephyr functionality
-  set(INCLUDE_PATHS "")
-  list(APPEND INCLUDE_PATHS "-I" "${CMAKE_BINARY_DIR}/modules/lang-swift/zephyr")
-
-  # Discover available Swift libraries registered during configuration
-  set(AVAILABLE_LIBS "")
-
-  # Build a comprehensive list of extra module directories for Swift library discovery
-  # This includes both ZEPHYR_EXTRA_MODULES (user-specified) and EXTRA_ZEPHYR_MODULES
-  # (Zephyr's merged list). We normalize all paths to absolute, real paths to ensure
-  # consistent matching during library discovery.
-  set(_SWIFT_EXTRA_MODULE_DIRS "")
-  foreach(_SWIFT_MODULE_ROOT ${ZEPHYR_EXTRA_MODULES} ${EXTRA_ZEPHYR_MODULES})
-    if(NOT _SWIFT_MODULE_ROOT)
-      continue()
-    endif()
-    # Convert relative paths to absolute paths based on current source directory
-    set(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT}")
-    if(NOT IS_ABSOLUTE "${_SWIFT_MODULE_ROOT_ABS}")
-      get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" ABSOLUTE
-                             BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-    endif()
-    # Resolve any symbolic links to get the canonical path
-    get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" REALPATH)
-    if(IS_DIRECTORY "${_SWIFT_MODULE_ROOT_ABS}")
-      list(APPEND _SWIFT_EXTRA_MODULE_DIRS "${_SWIFT_MODULE_ROOT_ABS}")
-    endif()
-  endforeach()
-  list(REMOVE_DUPLICATES _SWIFT_EXTRA_MODULE_DIRS)
-
-  # Discover available Swift libraries from the global registry
-  # The ZEPHYR_SWIFT_LIBRARY_INFO property contains entries in "name|source_dir" format
-  # We filter these to include only libraries within our configured extra module directories
-  set(POSSIBLE_MODULES "")
-  get_property(_SWIFT_LIBRARY_REGISTRY GLOBAL PROPERTY ZEPHYR_SWIFT_LIBRARY_INFO)
-  if(_SWIFT_LIBRARY_REGISTRY)
-    foreach(_ENTRY ${_SWIFT_LIBRARY_REGISTRY})
-      # Parse the registry entry format: "module_name|source_directory"
-      string(FIND "${_ENTRY}" "|" _ENTRY_SEPARATOR)
-      if(_ENTRY_SEPARATOR LESS 0)
-        continue() # Skip malformed entries
-      endif()
-      string(SUBSTRING "${_ENTRY}" 0 ${_ENTRY_SEPARATOR} _REGISTERED_MODULE_NAME)
-      math(EXPR _ENTRY_VALUE_START "${_ENTRY_SEPARATOR} + 1")
-      string(SUBSTRING "${_ENTRY}" ${_ENTRY_VALUE_START} -1 _REGISTERED_SOURCE_DIR)
-
-      # Skip the current library itself to avoid circular dependencies
-      if("${_REGISTERED_MODULE_NAME}" STREQUAL "${SWIFTLIB_MODULE_NAME}")
-        continue()
-      endif()
-
-      # Check if this library's source directory is within our extra module paths
-      # This ensures we only link libraries that are part of the current project's modules
-      set(_MODULE_IN_EXTRA FALSE)
-      foreach(_MODULE_DIR ${_SWIFT_EXTRA_MODULE_DIRS})
-        string(FIND "${_REGISTERED_SOURCE_DIR}/" "${_MODULE_DIR}/" _MATCH_POS)
-        if(_MATCH_POS EQUAL 0)
-          set(_MODULE_IN_EXTRA TRUE)
-          break()
-        endif()
-      endforeach()
-
-      # Skip libraries that aren't in our extra module directories
-      if(NOT _MODULE_IN_EXTRA)
-        continue()
-      endif()
-
-      # Verify that the library's compilation target exists before including it
-      if(NOT TARGET ${_REGISTERED_MODULE_NAME}_compile)
-        continue()
-      endif()
-
-      list(APPEND POSSIBLE_MODULES "${_REGISTERED_MODULE_NAME}")
-    endforeach()
-    list(REMOVE_DUPLICATES POSSIBLE_MODULES)
-  endif()
-
-  foreach(MODULE_NAME ${POSSIBLE_MODULES})
-    # Add the module's output directory to Swift include paths
-    set(MODULE_PATH "${CMAKE_BINARY_DIR}/modules/${MODULE_NAME}")
-    list(APPEND INCLUDE_PATHS "-I" "${MODULE_PATH}")
-    # Track this library for dependency management
-    list(APPEND AVAILABLE_LIBS "${MODULE_NAME}")
-  endforeach()
+  # Discover available Swift libraries using the shared discovery function
+  # Exclude the current library to avoid circular dependencies
+  _swift_discover_libraries(EXCLUDE_MODULE "${SWIFTLIB_MODULE_NAME}")
+  set(INCLUDE_PATHS "${SWIFT_INCLUDE_PATHS}")
+  set(AVAILABLE_LIBS "${SWIFT_AVAILABLE_LIBS}")
 
   # Set up compilation dependencies to ensure proper build order Always depend
   # on the source files themselves

--- a/cmake/SwiftLibrary.cmake
+++ b/cmake/SwiftLibrary.cmake
@@ -174,6 +174,87 @@ function(zephyr_swift_library)
   set(INCLUDE_PATHS "")
   list(APPEND INCLUDE_PATHS "-I" "${CMAKE_BINARY_DIR}/modules/lang-swift/zephyr")
 
+  # Discover available Swift libraries registered during configuration
+  set(AVAILABLE_LIBS "")
+
+  # Build a comprehensive list of extra module directories for Swift library discovery
+  # This includes both ZEPHYR_EXTRA_MODULES (user-specified) and EXTRA_ZEPHYR_MODULES
+  # (Zephyr's merged list). We normalize all paths to absolute, real paths to ensure
+  # consistent matching during library discovery.
+  set(_SWIFT_EXTRA_MODULE_DIRS "")
+  foreach(_SWIFT_MODULE_ROOT ${ZEPHYR_EXTRA_MODULES} ${EXTRA_ZEPHYR_MODULES})
+    if(NOT _SWIFT_MODULE_ROOT)
+      continue()
+    endif()
+    # Convert relative paths to absolute paths based on current source directory
+    set(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT}")
+    if(NOT IS_ABSOLUTE "${_SWIFT_MODULE_ROOT_ABS}")
+      get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" ABSOLUTE
+                             BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
+    # Resolve any symbolic links to get the canonical path
+    get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" REALPATH)
+    if(IS_DIRECTORY "${_SWIFT_MODULE_ROOT_ABS}")
+      list(APPEND _SWIFT_EXTRA_MODULE_DIRS "${_SWIFT_MODULE_ROOT_ABS}")
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES _SWIFT_EXTRA_MODULE_DIRS)
+
+  # Discover available Swift libraries from the global registry
+  # The ZEPHYR_SWIFT_LIBRARY_INFO property contains entries in "name|source_dir" format
+  # We filter these to include only libraries within our configured extra module directories
+  set(POSSIBLE_MODULES "")
+  get_property(_SWIFT_LIBRARY_REGISTRY GLOBAL PROPERTY ZEPHYR_SWIFT_LIBRARY_INFO)
+  if(_SWIFT_LIBRARY_REGISTRY)
+    foreach(_ENTRY ${_SWIFT_LIBRARY_REGISTRY})
+      # Parse the registry entry format: "module_name|source_directory"
+      string(FIND "${_ENTRY}" "|" _ENTRY_SEPARATOR)
+      if(_ENTRY_SEPARATOR LESS 0)
+        continue() # Skip malformed entries
+      endif()
+      string(SUBSTRING "${_ENTRY}" 0 ${_ENTRY_SEPARATOR} _REGISTERED_MODULE_NAME)
+      math(EXPR _ENTRY_VALUE_START "${_ENTRY_SEPARATOR} + 1")
+      string(SUBSTRING "${_ENTRY}" ${_ENTRY_VALUE_START} -1 _REGISTERED_SOURCE_DIR)
+
+      # Skip the current library itself to avoid circular dependencies
+      if("${_REGISTERED_MODULE_NAME}" STREQUAL "${SWIFTLIB_MODULE_NAME}")
+        continue()
+      endif()
+
+      # Check if this library's source directory is within our extra module paths
+      # This ensures we only link libraries that are part of the current project's modules
+      set(_MODULE_IN_EXTRA FALSE)
+      foreach(_MODULE_DIR ${_SWIFT_EXTRA_MODULE_DIRS})
+        string(FIND "${_REGISTERED_SOURCE_DIR}/" "${_MODULE_DIR}/" _MATCH_POS)
+        if(_MATCH_POS EQUAL 0)
+          set(_MODULE_IN_EXTRA TRUE)
+          break()
+        endif()
+      endforeach()
+
+      # Skip libraries that aren't in our extra module directories
+      if(NOT _MODULE_IN_EXTRA)
+        continue()
+      endif()
+
+      # Verify that the library's compilation target exists before including it
+      if(NOT TARGET ${_REGISTERED_MODULE_NAME}_compile)
+        continue()
+      endif()
+
+      list(APPEND POSSIBLE_MODULES "${_REGISTERED_MODULE_NAME}")
+    endforeach()
+    list(REMOVE_DUPLICATES POSSIBLE_MODULES)
+  endif()
+
+  foreach(MODULE_NAME ${POSSIBLE_MODULES})
+    # Add the module's output directory to Swift include paths
+    set(MODULE_PATH "${CMAKE_BINARY_DIR}/modules/${MODULE_NAME}")
+    list(APPEND INCLUDE_PATHS "-I" "${MODULE_PATH}")
+    # Track this library for dependency management
+    list(APPEND AVAILABLE_LIBS "${MODULE_NAME}")
+  endforeach()
+
   # Set up compilation dependencies to ensure proper build order Always depend
   # on the source files themselves
   set(COMPILE_DEPS ${SWIFTLIB_SOURCES})
@@ -183,6 +264,14 @@ function(zephyr_swift_library)
   if(TARGET Zephyr_compile)
     list(APPEND COMPILE_DEPS Zephyr_compile)
   endif()
+
+  # Add dependencies on all discovered Swift libraries This ensures they are
+  # compiled before the current library
+  foreach(LIB ${AVAILABLE_LIBS})
+    if(TARGET ${LIB}_compile)
+      list(APPEND COMPILE_DEPS ${LIB}_compile)
+    endif()
+  endforeach()
 
   # Locate the Swift compiler executable
   find_program(SWIFTC_EXECUTABLE swiftc REQUIRED)

--- a/cmake/SwiftSupport.cmake
+++ b/cmake/SwiftSupport.cmake
@@ -58,6 +58,125 @@ Ensure your ``prj.conf`` includes:
 
 #]=======================================================================]
 
+# .rst: .. cmake:command:: _swift_discover_libraries
+#
+# Internal function to discover available Swift libraries from the global registry
+# and build include paths and dependency lists for compilation.
+#
+# This function encapsulates the common library discovery logic used by both
+# zephyr_swift_application() and zephyr_swift_library() functions.
+#
+# **Parameters:**
+#
+# ``EXCLUDE_MODULE <name>``
+#   Optional. Module name to exclude from discovery (used by libraries to avoid
+#   circular dependencies with themselves).
+#
+# **Output Variables:**
+#
+# ``SWIFT_INCLUDE_PATHS``
+#   List of "-I" flags for Swift module search paths
+#
+# ``SWIFT_AVAILABLE_LIBS``
+#   List of discovered library names for dependency management
+#
+function(_swift_discover_libraries)
+  # Parse function arguments
+  cmake_parse_arguments(PARSE_ARGV 0 SWIFTDISCO "" "EXCLUDE_MODULE" "")
+
+  # Initialize output variables in parent scope
+  set(SWIFT_INCLUDE_PATHS "" PARENT_SCOPE)
+  set(SWIFT_AVAILABLE_LIBS "" PARENT_SCOPE)
+
+  # Start with the core Zephyr Swift module (always required)
+  set(INCLUDE_PATHS "")
+  list(APPEND INCLUDE_PATHS "-I" "${CMAKE_BINARY_DIR}/modules/lang-swift/zephyr")
+
+  # Build a comprehensive list of extra module directories for Swift library discovery
+  # This includes both ZEPHYR_EXTRA_MODULES (user-specified) and EXTRA_ZEPHYR_MODULES
+  # (Zephyr's merged list). We normalize all paths to absolute, real paths to ensure
+  # consistent matching during library discovery.
+  set(_SWIFT_EXTRA_MODULE_DIRS "")
+  foreach(_SWIFT_MODULE_ROOT ${ZEPHYR_EXTRA_MODULES} ${EXTRA_ZEPHYR_MODULES})
+    if(NOT _SWIFT_MODULE_ROOT)
+      continue()
+    endif()
+    # Convert relative paths to absolute paths based on current source directory
+    set(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT}")
+    if(NOT IS_ABSOLUTE "${_SWIFT_MODULE_ROOT_ABS}")
+      get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" ABSOLUTE
+                             BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
+    # Resolve any symbolic links to get the canonical path
+    get_filename_component(_SWIFT_MODULE_ROOT_ABS "${_SWIFT_MODULE_ROOT_ABS}" REALPATH)
+    if(IS_DIRECTORY "${_SWIFT_MODULE_ROOT_ABS}")
+      list(APPEND _SWIFT_EXTRA_MODULE_DIRS "${_SWIFT_MODULE_ROOT_ABS}")
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES _SWIFT_EXTRA_MODULE_DIRS)
+
+  # Discover available Swift libraries from the global registry
+  # The ZEPHYR_SWIFT_LIBRARY_INFO property contains entries in "name|source_dir" format
+  # We filter these to include only libraries within our configured extra module directories
+  set(POSSIBLE_MODULES "")
+  get_property(_SWIFT_LIBRARY_REGISTRY GLOBAL PROPERTY ZEPHYR_SWIFT_LIBRARY_INFO)
+  if(_SWIFT_LIBRARY_REGISTRY)
+    foreach(_ENTRY ${_SWIFT_LIBRARY_REGISTRY})
+      # Parse the registry entry format: "module_name|source_directory"
+      string(FIND "${_ENTRY}" "|" _ENTRY_SEPARATOR)
+      if(_ENTRY_SEPARATOR LESS 0)
+        continue() # Skip malformed entries
+      endif()
+      string(SUBSTRING "${_ENTRY}" 0 ${_ENTRY_SEPARATOR} _REGISTERED_MODULE_NAME)
+      math(EXPR _ENTRY_VALUE_START "${_ENTRY_SEPARATOR} + 1")
+      string(SUBSTRING "${_ENTRY}" ${_ENTRY_VALUE_START} -1 _REGISTERED_SOURCE_DIR)
+
+      # Skip the excluded module (used by libraries to avoid circular dependencies)
+      if(SWIFTDISCO_EXCLUDE_MODULE AND "${_REGISTERED_MODULE_NAME}" STREQUAL "${SWIFTDISCO_EXCLUDE_MODULE}")
+        continue()
+      endif()
+
+      # Check if this library's source directory is within our extra module paths
+      # This ensures we only link libraries that are part of the current project's modules
+      set(_MODULE_IN_EXTRA FALSE)
+      foreach(_MODULE_DIR ${_SWIFT_EXTRA_MODULE_DIRS})
+        string(FIND "${_REGISTERED_SOURCE_DIR}/" "${_MODULE_DIR}/" _MATCH_POS)
+        if(_MATCH_POS EQUAL 0)
+          set(_MODULE_IN_EXTRA TRUE)
+          break()
+        endif()
+      endforeach()
+
+      # Skip libraries that aren't in our extra module directories
+      if(NOT _MODULE_IN_EXTRA)
+        continue()
+      endif()
+
+      # Verify that the library's compilation target exists before including it
+      if(NOT TARGET ${_REGISTERED_MODULE_NAME}_compile)
+        continue()
+      endif()
+
+      list(APPEND POSSIBLE_MODULES "${_REGISTERED_MODULE_NAME}")
+    endforeach()
+    list(REMOVE_DUPLICATES POSSIBLE_MODULES)
+  endif()
+
+  # Build include paths and track available libraries
+  set(AVAILABLE_LIBS "")
+  foreach(MODULE_NAME ${POSSIBLE_MODULES})
+    # Add the module's output directory to Swift include paths
+    set(MODULE_PATH "${CMAKE_BINARY_DIR}/modules/${MODULE_NAME}")
+    list(APPEND INCLUDE_PATHS "-I" "${MODULE_PATH}")
+    # Track this library for dependency management
+    list(APPEND AVAILABLE_LIBS "${MODULE_NAME}")
+  endforeach()
+
+  # Set output variables in parent scope
+  set(SWIFT_INCLUDE_PATHS "${INCLUDE_PATHS}" PARENT_SCOPE)
+  set(SWIFT_AVAILABLE_LIBS "${AVAILABLE_LIBS}" PARENT_SCOPE)
+endfunction()
+
 # Include Swift library building functions Provides: swift_library()
 include(${CMAKE_CURRENT_LIST_DIR}/SwiftLibrary.cmake)
 

--- a/zephyr-sys/include/BridgingHeader.h
+++ b/zephyr-sys/include/BridgingHeader.h
@@ -27,11 +27,17 @@
 // all the project configuration settings from prj.conf
 #include <autoconf.h>
 
+// Standard C library headers
+#include <errno.h>
+
 // ===== Zephyr Kernel APIs =====
 
 // Core kernel functionality including scheduling, threading, and
 // synchronization
 #include <zephyr/kernel.h>
+
+// Random number generation APIs
+#include <zephyr/random/random.h>
 
 // ===== Device and Hardware APIs =====
 

--- a/zephyr-sys/include/module.modulemap
+++ b/zephyr-sys/include/module.modulemap
@@ -63,7 +63,8 @@
  * - header: Specifies the main header file containing C API definitions
  * - export *: Makes all symbols from the header available to importing Swift code
  */
-module ZephyrSys [system] {
-  header "BridgingHeader.h"
+module ZephyrSys {
+  umbrella header "BridgingHeader.h"
+  link "ZephyrSys"
   export *
 }

--- a/zephyr/lib/Error.swift
+++ b/zephyr/lib/Error.swift
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Linaro LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import ZephyrSys
+
+public typealias ZephyrResult<T> = Swift.Result<T, ZephyrError>
+
+public struct ZephyrError {
+  public let errno: Int32
+
+  @inlinable
+  public init(errno: Int32) {
+    self.errno = errno
+  }
+}
+
+// MARK: - Extension
+
+extension ZephyrError:
+  CustomDebugStringConvertible,
+  CustomStringConvertible,
+  Sendable,
+  Swift.Error
+  {}
+
+// MARK: - Public
+
+public extension ZephyrError {
+  var description: String { "zephyr error errno:\(errno)" }
+  var debugDescription: String { "zephyr error errno:\(errno)" }
+}
+
+public extension Result where Failure == ZephyrError {
+  @inlinable
+  func get() throws -> Success {
+    switch self {
+    case .success(let value):
+      return value
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+@inlinable
+public func toResult(_ code: Int32) -> ZephyrResult<Int32> {
+  if code < 0 {
+    .failure(ZephyrError(errno: Int32(-code)))
+  } else {
+    .success(code)
+  }
+}
+
+@inlinable
+public func toResultVoid(_ code: Int32) -> ZephyrResult<Void> {
+  toResult(code).map { _ in () }
+}

--- a/zephyr/lib/Zephyr.swift
+++ b/zephyr/lib/Zephyr.swift
@@ -2,3 +2,5 @@
 // Copyright (c) 2025 Schubert Anselme <schubert@anselm.es>
 
 import ZephyrSys
+
+public typealias Error = ZephyrError

--- a/zephyr/lib/time/Duration.swift
+++ b/zephyr/lib/time/Duration.swift
@@ -3,7 +3,11 @@
 
 import ZephyrSys
 
+// MARK: - Extension
+
 extension Duration: TimeoutConvertible {}
+
+// MARK: - Public
 
 public extension Duration {
   var ticks: Tick {

--- a/zephyr/lib/time/Instant.swift
+++ b/zephyr/lib/time/Instant.swift
@@ -4,9 +4,20 @@
 import ZephyrSys
 
 #if CONFIG_TIMEOUT_64BIT
-public struct Instant: Equatable, Comparable, Sendable, TimeoutConvertible {
+public struct Instant {
   public let ticks: Tick
 }
+
+// MARK: - Extension
+
+extension Instant:
+  Comparable,
+  Equatable ,
+  Sendable,
+  TimeoutConvertible
+  {}
+
+// MARK: - Public
 
 public extension Instant {
   init(ticks: Tick) { self.ticks = ticks }

--- a/zephyr/lib/time/Time.swift
+++ b/zephyr/lib/time/Time.swift
@@ -3,8 +3,6 @@
 
 import ZephyrSys
 
-// MARK: - Public API
-
 #if CONFIG_TIMEOUT_64BIT
 public typealias Tick = Int64
 #else
@@ -13,13 +11,27 @@ public typealias Tick = Int32
 
 public var SYS_FREQUENCY: Int32 { return CONFIG_SYS_CLOCK_TICKS_PER_SEC }
 
-public struct Forever: Sendable, TimeoutConvertible {
+public struct Forever {
   public func toTimeout() -> Timeout { Timeout(from: self) }
 }
 
-public struct NoWait: Sendable, TimeoutConvertible {
+public struct NoWait {
   public func toTimeout() -> Timeout { Timeout(from: self) }
 }
+
+// MARK: - Extension
+
+extension Forever:
+  Sendable,
+  TimeoutConvertible
+  {}
+
+extension NoWait:
+  Sendable,
+  TimeoutConvertible
+ {}
+
+// MARK: - Public
 
 @discardableResult
 public func sleep<T: TimeoutConvertible>(_ timeout: T) -> Duration {
@@ -34,7 +46,7 @@ public func now() -> Instant {
 }
 #endif
 
-// MARK: - Internal API
+// MARK: - Internal
 
 func checkedCast<T: BinaryInteger, U: BinaryInteger>(_ value: T) -> U {
   #if DEBUG

--- a/zephyr/lib/time/Timeout.swift
+++ b/zephyr/lib/time/Timeout.swift
@@ -7,9 +7,18 @@ public protocol TimeoutConvertible {
   func toTimeout() -> Timeout
 }
 
-public struct Timeout: Equatable, Sendable {
+public struct Timeout {
   public let value: k_timeout_t
 }
+
+// MARK: - Extension
+
+extension Timeout:
+  Equatable,
+  Sendable
+  {}
+
+// MARK: - Public
 
 public extension Timeout {
   static let forever = k_timeout_t(ticks: -1)


### PR DESCRIPTION
This pull request refactors the Swift library and application build logic in CMake to centralize and reuse Swift library/module discovery, improves dependency management, and introduces a standardized error handling type for Zephyr Swift bindings. It also applies code style improvements to several time-related types and updates C bridging and module mapping for better Swift interoperability.

**Build system improvements**

* Introduced the `_swift_discover_libraries` function in `cmake/SwiftSupport.cmake` to encapsulate Swift library discovery logic, reducing duplication and improving maintainability. Both `zephyr_swift_application()` and `zephyr_swift_library()` now use this shared function for building include paths and library lists. [[1]](diffhunk://#diff-6094dda4a1a8f4cf0386e8c9f633a169ed1e30eaac322794e8a56d3055de0f32R61-R179) [[2]](diffhunk://#diff-1ffee9fc009b0e53d0a5ba0033efc47e0397fe4bb2609aaa89bfa1efe84212e9L113-R116) [[3]](diffhunk://#diff-ac8a9ee87f55f364fb6e8bad04365bed32906ce1e6bf77348503c7bbecdf9bc9L172-R176)
* Added logic in `zephyr_swift_library()` to depend on all discovered Swift libraries, ensuring correct compilation order and avoiding circular dependencies by excluding the current library from discovery.

**Error handling improvements**

* Added new file `zephyr/lib/Error.swift` defining `ZephyrError` and `ZephyrResult`, providing a standardized error/result type for Zephyr Swift APIs. Also added convenience functions for converting error codes to results.
* Updated `zephyr/lib/Zephyr.swift` to alias `Error` to `ZephyrError` for consistent error usage across the codebase.

**Swift time API refinements**

* Refactored `Instant`, `Duration`, `Timeout`, `Forever`, and `NoWait` types to use protocol extensions for conformances (`Sendable`, `Equatable`, `TimeoutConvertible`, etc.), improving code clarity and maintainability. [[1]](diffhunk://#diff-c9136a0ec4edeee8f6946fb051ae408b3c02d48be5773e9b67242f66c7cd98bfL7-R21) [[2]](diffhunk://#diff-48d53c91d5f470d4f03c93dad0459983b70190693cb5205ff6f223de02f0f10aR6-R11) [[3]](diffhunk://#diff-57f96ec9d4dbce7ff96fc468c27981b5ad9fa9a7fbbd059afd4011d13427de8dL16-R35) [[4]](diffhunk://#diff-822b4400e0ad77fa2505175622f93dde45eed8713d496881821ae4bfec6c07f1L10-R22)
* Reorganized time-related files to use consistent MARK comments for public and extension sections, and made minor style improvements. [[1]](diffhunk://#diff-57f96ec9d4dbce7ff96fc468c27981b5ad9fa9a7fbbd059afd4011d13427de8dL6-L7) [[2]](diffhunk://#diff-57f96ec9d4dbce7ff96fc468c27981b5ad9fa9a7fbbd059afd4011d13427de8dL37-R49)

**C bridging and module mapping**

* Updated `zephyr-sys/include/BridgingHeader.h` to include `<errno.h>` and `<zephyr/random/random.h>` for error handling and random number support in Swift bindings.
* Changed `zephyr-sys/include/module.modulemap` to use an umbrella header and explicit linking, improving Swift module import and symbol visibility.